### PR TITLE
Ensure UID2Manager Has Started In init()

### DIFF
--- a/Sources/UID2IMAPlugin/UID2IMASecureSignalsAdapter.swift
+++ b/Sources/UID2IMAPlugin/UID2IMASecureSignalsAdapter.swift
@@ -12,7 +12,10 @@ import UID2
 @available(iOS 13.0, *)
 public class UID2IMASecureSignalsAdapter: NSObject {
     
-    required public override init() { }
+    required public override init() {
+        // Ensure UID2Manager has started
+        _ = UID2Manager.shared
+    }
     
 }
 


### PR DESCRIPTION
Add call to `UID2Manager.shared` to `IMASecureSingalsAdapter.init()` override to ensure that the singleton has been started before the IMA SDK requests data via Secure Signals during ad request process.

https://developers.google.com/interactive-media-ads/docs/sdks/ios/client-side/reference/Protocols/IMASecureSignalsAdapter#-init

Related:

* https://github.com/IABTechLab/uid2-android-sdk/blob/35103b9afaed0bfc5c094d0674b2f7b870d2bee2/securesignals-ima/src/main/java/com/uid2/securesignals/ima/UID2SecureSignalsAdapter.kt#L38-L45
* https://github.com/IABTechLab/uid2-ios-plugin-google-gma/pull/4
