### PR TITLE
SPM Support for IMA SDK

### DIFF
--- a/Development/UID2GoogleIMADevelopmentApp/UID2GoogleIMADevelopmentApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Development/UID2GoogleIMADevelopmentApp/UID2GoogleIMADevelopmentApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "swift-package-manager-google-interactive-media-ads-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-interactive-media-ads-ios.git",
+      "state" : {
+        "revision" : "d2a86d37798cfb609bd2bedaef81d332dac5d5eb",
+        "version" : "3.19.1"
+      }
+    },
+    {
       "identity" : "uid2-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/IABTechLab/uid2-ios-sdk.git",

--- a/Package.swift
+++ b/Package.swift
@@ -15,21 +15,16 @@ let package = Package(
             targets: ["UID2IMAPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", from: "0.2.0")
-        // Google IMA SDK will become a dependency here once Google adds SPM support (Expected Q2 2023)
+        .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", from: "0.2.0"),
+        .package(url: "https://github.com/googleads/swift-package-manager-google-interactive-media-ads-ios.git", from: "3.18.5")
     ],
     targets: [
         .target(
             name: "UID2IMAPlugin",
             dependencies: [
                 .product(name: "UID2", package: "uid2-ios-sdk"),
-                "GoogleInteractiveMediaAds"
+                .product(name: "GoogleInteractiveMediaAds", package: "swift-package-manager-google-interactive-media-ads-ios")
             ]),
-        // Binary Target will removed once Google IMA supports SPM (Expected Q2 2023)
-        // IMA 3.18.5 is first public beta of IMA with Secure Signals
-        .binaryTarget(name: "GoogleInteractiveMediaAds",
-                      url: "https://imasdk.googleapis.com/native/downloads/ima-ios-v3.18.5.zip",
-                      checksum: "f8473b337f4a24d0cf92e3e25227a9d33de139597b18332c368629ed30871422"),
         .testTarget(
             name: "UID2IMAPluginTests",
             dependencies: ["UID2IMAPlugin"],


### PR DESCRIPTION
Use Google's new SPM support for the IMA SDK.  This enables the iOS IMA Plugin to be much more flexible in supporting different versions of the Google IMA SDK that customers may be using, thus removing friction from their integration.

Per Google's suggestion the iOS IMA Plugin will support IMA SDK v3.18.5 and above.