### PR TITLE
Fix resource bundle name conflict

### DIFF
--- a/Sources/UID2IMAPlugin/UID2IMASecureSignalsAdapter.swift
+++ b/Sources/UID2IMAPlugin/UID2IMASecureSignalsAdapter.swift
@@ -26,7 +26,7 @@ extension UID2IMASecureSignalsAdapter: IMASecureSignalsAdapter {
         let version = IMAVersion()
         version.majorVersion = 0
         version.minorVersion = 3
-        version.patchVersion = 2
+        version.patchVersion = 3
         return version
     }
     

--- a/UID2IMAPlugin.podspec.json
+++ b/UID2IMAPlugin.podspec.json
@@ -3,13 +3,13 @@
   "summary": "A plugin for integrating UID2 and Google IMA into iOS applications.",
   "homepage": "https://unifiedid.com/",
   "license": "Apache License, Version 2.0",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "authors": {
     "David Snabel-Caunt": "dave.snabel-caunt@thetradedesk.com"
   },
   "source": {
     "git": "https://github.com/IABTechLab/uid2-ios-plugin-google-ima.git",
-    "tag": "v0.3.2"
+    "tag": "v0.3.3"
   },
   "platforms": {
     "ios": "13.0"
@@ -20,7 +20,7 @@
   "frameworks": "Foundation",
   "static_framework": true,
   "resource_bundles": {
-    "UID2": ["Sources/UID2IMAPlugin/PrivacyInfo.xcprivacy"]
+    "UID2IMAPlugin": ["Sources/UID2IMAPlugin/PrivacyInfo.xcprivacy"]
   },
   "source_files": [
     "Sources/UID2IMAPlugin/**/*"


### PR DESCRIPTION
The podspec mistakenly uses the resource bundle name `UID2` which causes Xcode archiving to fail, as it will conflict with the UID2 SDK's resource bundle. Rename to match the spec name.

Bump version to 0.3.3 ready to release.