### PR TITLE
Check iOS 13 is available at runtime

### DIFF
--- a/Sources/UID2IMAPlugin/AdvertisingTokenNotFoundError.swift
+++ b/Sources/UID2IMAPlugin/AdvertisingTokenNotFoundError.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Advertising Token Not Found for IMA Adapter
 @objc(UID2IMAAdvertisingTokenNotFoundError)
-public class AdvertisingTokenNotFoundError: NSError {
+public class AdvertisingTokenNotFoundError: NSError, @unchecked Sendable {
     
     convenience init() {
         self.init(domain: "UID", code: 1)

--- a/Sources/UID2IMAPlugin/EUIDIMASecureSignalsAdapter.swift
+++ b/Sources/UID2IMAPlugin/EUIDIMASecureSignalsAdapter.swift
@@ -11,6 +11,9 @@ import UID2
 public class EUIDIMASecureSignalsAdapter: NSObject {
     
     required public override init() {
+        guard isOperatingSystemSupported else {
+            return
+        }
         // Ensure UID2Manager has started
         _ = EUIDManager.shared
     }
@@ -24,7 +27,7 @@ extension EUIDIMASecureSignalsAdapter: IMASecureSignalsAdapter {
         let version = IMAVersion()
         version.majorVersion = 1
         version.minorVersion = 0
-        version.patchVersion = 0
+        version.patchVersion = 1
         return version
     }
     
@@ -38,6 +41,10 @@ extension EUIDIMASecureSignalsAdapter: IMASecureSignalsAdapter {
     }
     
     public func collectSignals(completion: @escaping IMASignalCompletionHandler) {
+        guard isOperatingSystemSupported else {
+            completion(nil, OperatingSystemUnsupportedError())
+            return
+        }
         Task {
             guard let advertisingToken = await EUIDManager.shared.getAdvertisingToken() else {
                 completion(nil, AdvertisingTokenNotFoundError())

--- a/Sources/UID2IMAPlugin/OperatingSystemSupport.swift
+++ b/Sources/UID2IMAPlugin/OperatingSystemSupport.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Adapter implementations in this package are called at runtime, ignoring @available attributes.
+/// By checking the operating system version we can avoid calling UID code which is unavailable.
+let isOperatingSystemSupported = ProcessInfo.processInfo.isOperatingSystemAtLeast(
+    .init(
+        majorVersion: 13,
+        minorVersion: 0,
+        patchVersion: 0
+    )
+)
+
+/// Adapter called on an unsupported operating system version i.e. lower than UID2's deployment target.
+@objc(UID2GMAOperatingSystemUnsupported)
+public final class OperatingSystemUnsupportedError: NSError, @unchecked Sendable {
+
+    convenience init() {
+        self.init(domain: "UID", code: 2)
+    }
+}

--- a/Sources/UID2IMAPlugin/UID2IMASecureSignalsAdapter.swift
+++ b/Sources/UID2IMAPlugin/UID2IMASecureSignalsAdapter.swift
@@ -12,8 +12,11 @@ import UID2
 @available(iOS 13.0, *)
 @objc(UID2IMASecureSignalsAdapter)
 public class UID2IMASecureSignalsAdapter: NSObject {
-    
+
     required public override init() {
+        guard isOperatingSystemSupported else {
+            return
+        }
         // Ensure UID2Manager has started
         _ = UID2Manager.shared
     }
@@ -27,7 +30,7 @@ extension UID2IMASecureSignalsAdapter: IMASecureSignalsAdapter {
         let version = IMAVersion()
         version.majorVersion = 1
         version.minorVersion = 0
-        version.patchVersion = 0
+        version.patchVersion = 1
         return version
     }
     
@@ -41,7 +44,10 @@ extension UID2IMASecureSignalsAdapter: IMASecureSignalsAdapter {
     }
     
     public func collectSignals(completion: @escaping IMASignalCompletionHandler) {
-        
+        guard isOperatingSystemSupported else {
+            completion(nil, OperatingSystemUnsupportedError())
+            return
+        }
         Task {
             guard let advertisingToken = await UID2Manager.shared.getAdvertisingToken() else {
                 completion(nil, AdvertisingTokenNotFoundError())

--- a/UID2IMAPlugin.podspec.json
+++ b/UID2IMAPlugin.podspec.json
@@ -3,13 +3,13 @@
   "summary": "A plugin for integrating UID2 and Google IMA into iOS applications.",
   "homepage": "https://unifiedid.com/",
   "license": "Apache License, Version 2.0",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "authors": {
     "David Snabel-Caunt": "dave.snabel-caunt@thetradedesk.com"
   },
   "source": {
     "git": "https://github.com/IABTechLab/uid2-ios-plugin-google-ima.git",
-    "tag": "v1.0.0"
+    "tag": "v1.0.1"
   },
   "platforms": {
     "ios": "12.0"


### PR DESCRIPTION
Fixes a crash on iOS 12 when the adapters are called at runtime.

Check and cache operating system version, using this to no-op adapter calls on operating systems prior to iOS 13. `#available` checks do work for this, but produce a warning because the compiler knows the enclosing scope is already annotated with @available. Using ProcessInfo avoids these warnings.