### PR TITLE
Only include swift in podspec source_files

### DIFF
--- a/UID2IMAPlugin.podspec.json
+++ b/UID2IMAPlugin.podspec.json
@@ -23,7 +23,7 @@
     "UID2IMAPlugin": ["Sources/UID2IMAPlugin/PrivacyInfo.xcprivacy"]
   },
   "source_files": [
-    "Sources/UID2IMAPlugin/**/*"
+    "Sources/UID2IMAPlugin/**/*.swift"
   ],
   "dependencies": {
     "GoogleAds-IMA-iOS-SDK": [


### PR DESCRIPTION
Xcode warns there is no rule to process the `PrivacyInfo.xcprivacy` file. Remove it from sources, as it is a resource.