### PR TITLE
Bump version to 1.0.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["UID2IMAPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", "1.7.0" ..< "2.0.0"),
+        .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", "1.7.0" ..< "3.0.0"),
         .package(url: "https://github.com/googleads/swift-package-manager-google-interactive-media-ads-ios.git", from: "3.18.5")
     ],
     targets: [

--- a/Sources/UID2IMAPlugin/EUIDIMASecureSignalsAdapter.swift
+++ b/Sources/UID2IMAPlugin/EUIDIMASecureSignalsAdapter.swift
@@ -27,7 +27,7 @@ extension EUIDIMASecureSignalsAdapter: IMASecureSignalsAdapter {
         let version = IMAVersion()
         version.majorVersion = 1
         version.minorVersion = 0
-        version.patchVersion = 3
+        version.patchVersion = 4
         return version
     }
     

--- a/Sources/UID2IMAPlugin/UID2IMASecureSignalsAdapter.swift
+++ b/Sources/UID2IMAPlugin/UID2IMASecureSignalsAdapter.swift
@@ -30,7 +30,7 @@ extension UID2IMASecureSignalsAdapter: IMASecureSignalsAdapter {
         let version = IMAVersion()
         version.majorVersion = 1
         version.minorVersion = 0
-        version.patchVersion = 3
+        version.patchVersion = 4
         return version
     }
     

--- a/UID2IMAPlugin.podspec.json
+++ b/UID2IMAPlugin.podspec.json
@@ -3,13 +3,13 @@
   "summary": "A plugin for integrating UID2 and Google IMA into iOS applications.",
   "homepage": "https://unifiedid.com/",
   "license": "Apache License, Version 2.0",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "authors": {
     "David Snabel-Caunt": "dave.snabel-caunt@thetradedesk.com"
   },
   "source": {
     "git": "https://github.com/IABTechLab/uid2-ios-plugin-google-ima.git",
-    "tag": "v1.0.3"
+    "tag": "v1.0.4"
   },
   "platforms": {
     "ios": "12.0"
@@ -31,7 +31,7 @@
     ],
     "UID2": [
       ">= 1.7.0",
-      "< 2.0"
+      "< 3.0"
     ]
   }
 }


### PR DESCRIPTION
Release a new patch version to allow usage of UID2 SDK v3. There are no breaking changes or functional changes between v2 and v3, but UID2's major version is incrementing in lockstep with UID2Prebid.