### PR TITLE
UID2-7198: Bump minimum iOS deployment target from 12.0 to 15.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "UID2IMAPlugin",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v12)
+        .iOS(.v15)
     ],
     products: [
         .library(

--- a/UID2IMAPlugin.podspec.json
+++ b/UID2IMAPlugin.podspec.json
@@ -12,7 +12,7 @@
     "tag": "v1.0.4"
   },
   "platforms": {
-    "ios": "12.0"
+    "ios": "15.0"
   },
   "swift_versions": [
     "5"


### PR DESCRIPTION
## Summary

- Bumps `Package.swift` minimum platform from `.iOS(.v12)` → `.iOS(.v15)`
- Bumps `UID2IMAPlugin.podspec.json` `ios` minimum from `12.0` → `15.0`

## Problem

The `GoogleInteractiveMediaAds` Swift Package declares iOS 15.0 as its minimum platform version. Swift Package Manager enforces that a consuming package's minimum must be ≥ all its dependencies' minimums. As a result, any publisher adding `UID2IMAPlugin` via SPM gets the following build error:

> Package Product 'GoogleInteractiveMediaAds' — Requirement: Minimum platform version 15.0 for the iOS platform — Current Configuration: Target 'UID2IMAPlugin' currently supports version 12.0

Reported by Weather Channel via TAM (Slack: https://thetradedesk.slack.com/archives/C04TA13AQKF/p1779917294980149).

## Impact

This is a breaking change for publishers targeting iOS 12–14, but in practice:
- iOS 15 shipped September 2021; iOS 12–14 are 4+ years old
- Apple requires iOS 16+ for new App Store submissions
- Any publisher trying to use this plugin was already blocked at the `GoogleInteractiveMediaAds` dependency level

## Test plan

- [ ] CI passes (existing unit tests)
- [ ] Verify `Package.swift` resolves without SPM version conflict errors

Jira: https://thetradedesk.atlassian.net/browse/UID2-7198

🤖 Generated with [Claude Code](https://claude.com/claude-code)